### PR TITLE
Code Climate + Coverage Config and Example Specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       DATABASE_USERNAME: root
       DATABASE_HOST: localhost
       DATABASE_PORT: 5432
+      CC_TEST_REPORTER_ID: d51bea69a31c072d33ae2a74be689f925c9e6f61496e3eebd71d003cecc266d3
 
     docker:
     # specify the version you desire here
@@ -82,18 +83,25 @@ jobs:
     # Database setup
     - run: bin/setup
 
-    # run tests!
+    - run:
+        name: Setup Code Climate test-reporter
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+
     - run:
         name: run tests
         command: |
           mkdir /tmp/test-results
           TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
+          ./cc-test-reporter before-build
           bin/rspec --format progress \
                           --format RspecJunitFormatter \
                           --out /tmp/test-results/rspec.xml \
                           --format progress \
                           $TEST_FILES
+          ./cc-test-reporter after-build --exit-code $?
 
     # collect reports
     - store_test_results:

--- a/Gemfile
+++ b/Gemfile
@@ -88,8 +88,7 @@ group :test do
   gem "rspec_junit_formatter"
 
   # Coverage
-  gem 'simplecov'
-  gem 'codeclimate-test-reporter'
+  gem 'simplecov', require: false
 
   # Capybara for feature testing, Poltergeist for PhantomJS
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,8 +95,6 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
     cliver (0.3.2)
-    codeclimate-test-reporter (1.0.8)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
@@ -165,7 +163,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
-    docile (1.1.5)
+    docile (1.3.1)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -526,8 +524,8 @@ GEM
       redis (>= 3.3.5, < 5)
     sidekiq-failures (1.0.0)
       sidekiq (>= 4.0.0)
-    simplecov (0.13.0)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
@@ -577,7 +575,6 @@ DEPENDENCIES
   bootsnap
   byebug
   capybara
-  codeclimate-test-reporter
   cortex (~> 0.1)
   cortex-plugins-core (~> 3.1)
   database_cleaner

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ApplicationHelper. For example:
+#
+# describe ApplicationHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ApplicationHelper, type: :helper do
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationJob, type: :job do
+end

--- a/spec/mailers/application_spec.rb
+++ b/spec/mailers/application_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+end

--- a/spec/mailers/previews/application_preview.rb
+++ b/spec/mailers/previews/application_preview.rb
@@ -1,0 +1,3 @@
+# Preview all emails at http://localhost:3000/rails/mailers/application
+class ApplicationPreview < ActionMailer::Preview
+end


### PR DESCRIPTION
**Purpose**
This PR introduces Code Climate coverage reporting. It also adds basic example specs.

**JIRA**
N/A

**Changes**
* Improvements and fixes
  * Sets up Code Climate coverage reporting
  * Adds basic example specs
  * Sets `simplecov` to `require: false` in Gemfile
  * Removes deprecated Code Climate gem

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A

* After
N/A

**Feature Server**
N/A

**How to Verify These Changes**
* Specific pages to visit
  * N/A

* Steps to take
  * N/A

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies**
  * N/A

**Additional Information**
N/A